### PR TITLE
Agregue requerimientos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+blinker==1.7.0
+click==8.1.7
+colorama==0.4.6
+Flask==3.0.0
+Flask-WTF==1.2.1
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+Werkzeug==3.0.1
+WTForms==3.1.1


### PR DESCRIPTION
Faltaba agregar los requerimientos para poder instalar las librerías con un solo un comando.